### PR TITLE
Attempt to exclude columns before determining type

### DIFF
--- a/pydantic_sqlalchemy/main.py
+++ b/pydantic_sqlalchemy/main.py
@@ -17,11 +17,11 @@ def sqlalchemy_to_pydantic(
     for attr in mapper.attrs:
         if isinstance(attr, ColumnProperty):
             if attr.columns:
-                column = attr.columns[0]
-                python_type = column.type.python_type
                 name = attr.key
                 if name in exclude:
                     continue
+                column = attr.columns[0]
+                python_type = column.type.python_type
                 default = None
                 if column.default is None and not column.nullable:
                     default = ...


### PR DESCRIPTION
I have some tables that I'd like to exclude some fields that don't have a python type in sqlalchemy. I'd like to keep them in my model and process them into pydantic manually after the other fields get processed with this utility, but the exclude logic runs after the determination of the type, so I get a NotImplementedError() regardless of exclusion in this case. 

I'd like to just move the exclusion logic above the type determination, so that this wouldn't occur in my use-case.