### PR TITLE
Pass field params through sqlalchemy using unexisting dialect

### DIFF
--- a/pydantic_sqlalchemy/__init__.py
+++ b/pydantic_sqlalchemy/__init__.py
@@ -3,6 +3,7 @@ try:  # pragma: nocover
 except ImportError:
     from importlib_metadata import version  # type: ignore
 
+from .dialect import PydanticDialect
 from .main import sqlalchemy_to_pydantic
 
 __version__ = version(__package__)

--- a/pydantic_sqlalchemy/dialect.py
+++ b/pydantic_sqlalchemy/dialect.py
@@ -1,0 +1,13 @@
+from sqlalchemy.dialects import registry
+from sqlalchemy.engine.default import DefaultDialect
+
+
+class PydanticDialect(DefaultDialect):
+    """
+    Dialect to hide sqlalchemy error messages
+    """
+
+    pass
+
+
+registry.register("pydantic", __name__, "PydanticDialect")


### PR DESCRIPTION
Use `pydantic_` prefixed arguments to `sa.Column` to  pass them to `pydantic.Field`