### PR TITLE
add support for @property and @hybrid_property

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[report]
+exclude_lines =
+    pragma: no cover
+    if TYPE_CHECKING:

--- a/pydantic_sqlalchemy/main.py
+++ b/pydantic_sqlalchemy/main.py
@@ -13,8 +13,10 @@ class OrmConfig(BaseConfig):
 
 
 def sqlalchemy_to_pydantic(
-    db_model: Type, *, config: Type = OrmConfig, exclude: Container[str] = []
+    db_model: Type, *, config: Type = OrmConfig, exclude: Container[str] = None
 ) -> Type[BaseModel]:
+    exclude = exclude or []
+
     mapper = sqlalchemy.inspection.inspect(db_model)
     fields = {}
     for attr in mapper.attrs:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+from typing import TYPE_CHECKING, Callable, List, Optional
+
+import pytest
+from sqlalchemy.engine import create_engine
+from sqlalchemy.ext.declarative.api import declarative_base
+from sqlalchemy.orm.session import Session, sessionmaker
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.declarative import DeclarativeMeta
+
+
+@pytest.fixture
+def Base() -> "DeclarativeMeta":
+    return declarative_base()
+
+
+@pytest.fixture
+def create_db(Base) -> Callable:
+    def prepare_db(instances: Optional[List["DeclarativeMeta"]] = None) -> Session:
+        instances = instances or []
+
+        engine = create_engine("sqlite://", echo=True)
+        Base.metadata.create_all(engine)
+        LocalSession = sessionmaker(bind=engine)
+
+        session = LocalSession()
+        session.add_all(instances)
+        session.commit()
+
+        return session
+
+    return prepare_db


### PR DESCRIPTION
This PR adds support for attributes defined by `@property` or `@hybrid_property`. The corresponding functions must provide a type hint for the return type.

I'm not sure if I identify hybrid_properties the right way, or if the check is to broad.