### PR TITLE
FIX: give actual `pydantic` model class a `__name__` attribute

### DIFF
--- a/pydantic_sqlalchemy/main.py
+++ b/pydantic_sqlalchemy/main.py
@@ -35,4 +35,5 @@ def sqlalchemy_to_pydantic(
     pydantic_model = create_model(
         db_model.__name__, __config__=config, **fields  # type: ignore
     )
+    pydantic_model.__name__ = db_model.__name__
     return pydantic_model


### PR DESCRIPTION
Bugfix: give actual `pydantic` model class a `__name__` attribute.  Some other libraries seem to expect that these pydantic models have `__name__`s. 