### PR TITLE
Add support for making columns optional from Pydantic model

### DIFF
--- a/pydantic_sqlalchemy/main.py
+++ b/pydantic_sqlalchemy/main.py
@@ -10,7 +10,8 @@ class OrmConfig(BaseConfig):
 
 
 def sqlalchemy_to_pydantic(
-    db_model: Type, *, config: Type = OrmConfig, exclude: Container[str] = []
+    db_model: Type, *, config: Type = OrmConfig, exclude: Container[str] = [],
+        optional: Container[str] = [], all_optional: bool = False
 ) -> Type[BaseModel]:
     mapper = inspect(db_model)
     fields = {}
@@ -29,7 +30,7 @@ def sqlalchemy_to_pydantic(
                     python_type = column.type.python_type
                 assert python_type, f"Could not infer python_type for {column}"
                 default = None
-                if column.default is None and not column.nullable:
+                if not all_optional and name not in optional and column.default is None and not column.nullable:
                     default = ...
                 fields[name] = (python_type, default)
     pydantic_model = create_model(

--- a/tests/test_pydantic_sqlalchemy.py
+++ b/tests/test_pydantic_sqlalchemy.py
@@ -185,3 +185,30 @@ def test_exclude() -> None:
             {"email_address": "eddy@example.com", "id": 2},
         ],
     }
+
+
+def test_all_optional() -> None:
+    PydanticAddressAllOptional = sqlalchemy_to_pydantic(Address, all_optional=True)
+    schema_all_optional = PydanticAddressAllOptional.schema()
+    PydanticAddressEmailAdressOptional = sqlalchemy_to_pydantic(Address, optional=['email_address'])
+    schema_email_address_optional = PydanticAddressEmailAdressOptional.schema()
+
+    assert schema_all_optional == {
+        "title": "Address",
+        "type": "object",
+        "properties": {
+            "id": {"title": "Id", "type": "integer"},
+            "email_address": {"title": "Email Address", "type": "string"},
+            "user_id": {"title": "User Id", "type": "integer"},
+        },
+    }
+    assert schema_email_address_optional == {
+        "title": "Address",
+        "type": "object",
+        "properties": {
+            "id": {"title": "Id", "type": "integer"},
+            "email_address": {"title": "Email Address", "type": "string"},
+            "user_id": {"title": "User Id", "type": "integer"},
+        },
+        "required": ["id"],
+    }


### PR DESCRIPTION
Sometimes, when I use `sqlalchemy_to_pydantic` to create pydantic model, I want to make some columns and all columns to be optional for a patch requst. 