### PR TITLE
access-mapper-columns-instead-of-mapper-attrs

### DIFF
--- a/pydantic_sqlalchemy/main.py
+++ b/pydantic_sqlalchemy/main.py
@@ -2,7 +2,6 @@ from typing import Container, Optional, Type
 
 from pydantic import BaseConfig, BaseModel, create_model
 from sqlalchemy.inspection import inspect
-from sqlalchemy.orm.properties import ColumnProperty
 
 
 class OrmConfig(BaseConfig):
@@ -14,24 +13,21 @@ def sqlalchemy_to_pydantic(
 ) -> Type[BaseModel]:
     mapper = inspect(db_model)
     fields = {}
-    for attr in mapper.attrs:
-        if isinstance(attr, ColumnProperty):
-            if attr.columns:
-                name = attr.key
-                if name in exclude:
-                    continue
-                column = attr.columns[0]
-                python_type: Optional[type] = None
-                if hasattr(column.type, "impl"):
-                    if hasattr(column.type.impl, "python_type"):
-                        python_type = column.type.impl.python_type
-                elif hasattr(column.type, "python_type"):
-                    python_type = column.type.python_type
-                assert python_type, f"Could not infer python_type for {column}"
-                default = None
-                if column.default is None and not column.nullable:
-                    default = ...
-                fields[name] = (python_type, default)
+    for column in mapper.columns:
+        name = column.name
+        if name in exclude:
+            continue
+        python_type: Optional[type] = None
+        if hasattr(column.type, "impl"):
+            if hasattr(column.type.impl, "python_type"):
+                python_type = column.type.impl.python_type
+        elif hasattr(column.type, "python_type"):
+            python_type = column.type.python_type
+        assert python_type, f"Could not infer python_type for {column}"
+        default = None
+        if column.default is None and not column.nullable:
+            default = ...
+        fields[name] = (python_type, default)
     pydantic_model = create_model(
         db_model.__name__, __config__=config, **fields  # type: ignore
     )


### PR DESCRIPTION
Instead of checking `mapper.attrs` and then checking if `isinstance of ColumnProperty`, we can directly get columns using `mapper.columns`