### PR TITLE
WIP: Add optional model name and only parameter to sqlalchemy_to_pydantic

### DIFF
--- a/pydantic_sqlalchemy/main.py
+++ b/pydantic_sqlalchemy/main.py
@@ -10,7 +10,7 @@ class OrmConfig(BaseConfig):
 
 
 def sqlalchemy_to_pydantic(
-    db_model: Type, *, config: Type = OrmConfig, exclude: Container[str] = [], name: Optional[str]= None
+    db_model: Type, *, config: Type = OrmConfig, exclude: Container[str] = [], new_model_name: Optional[str]= None
 ) -> Type[BaseModel]:
     mapper = inspect(db_model)
     fields = {}
@@ -33,5 +33,5 @@ def sqlalchemy_to_pydantic(
                     default = ...
                 fields[name] = (python_type, default)
     return create_model(
-        name or db_model.__name__, __config__=config, **fields  # type: ignore
+        new_model_name or db_model.__name__, __config__=config, **fields  # type: ignore
     )

--- a/pydantic_sqlalchemy/main.py
+++ b/pydantic_sqlalchemy/main.py
@@ -10,7 +10,7 @@ class OrmConfig(BaseConfig):
 
 
 def sqlalchemy_to_pydantic(
-    db_model: Type, *, config: Type = OrmConfig, exclude: Container[str] = [], new_model_name: Optional[str]= None
+    db_model: Type, *, config: Type = OrmConfig, only: Optional[Container[str]] = None, exclude: Optional[Container[str]] = None, new_model_name: Optional[str]= None
 ) -> Type[BaseModel]:
     mapper = inspect(db_model)
     fields = {}
@@ -18,7 +18,7 @@ def sqlalchemy_to_pydantic(
         if isinstance(attr, ColumnProperty):
             if attr.columns:
                 name = attr.key
-                if name in exclude:
+                if (only and name not in only) or (exclude and name in exclude):
                     continue
                 column = attr.columns[0]
                 python_type: Optional[type] = None

--- a/pydantic_sqlalchemy/main.py
+++ b/pydantic_sqlalchemy/main.py
@@ -10,7 +10,7 @@ class OrmConfig(BaseConfig):
 
 
 def sqlalchemy_to_pydantic(
-    db_model: Type, *, config: Type = OrmConfig, exclude: Container[str] = []
+    db_model: Type, *, config: Type = OrmConfig, exclude: Container[str] = [], name: Optional[str]= None
 ) -> Type[BaseModel]:
     mapper = inspect(db_model)
     fields = {}
@@ -32,7 +32,6 @@ def sqlalchemy_to_pydantic(
                 if column.default is None and not column.nullable:
                     default = ...
                 fields[name] = (python_type, default)
-    pydantic_model = create_model(
-        db_model.__name__, __config__=config, **fields  # type: ignore
+    return create_model(
+        name or db_model.__name__, __config__=config, **fields  # type: ignore
     )
-    return pydantic_model

--- a/tests/test_pydantic_sqlalchemy.py
+++ b/tests/test_pydantic_sqlalchemy.py
@@ -185,3 +185,11 @@ def test_exclude() -> None:
             {"email_address": "eddy@example.com", "id": 2},
         ],
     }
+
+
+def test_only() -> None:
+    PydanticUser = sqlalchemy_to_pydantic(User, only={"nickname", "name"})
+    user = db.query(User).first()
+    pydantic_user = PydanticUser.from_orm(user)
+    data = pydantic_user.dict(by_alias=True)
+    assert data == {"nickname": "edsnickname", "name": "ed"}


### PR DESCRIPTION
I went ahead and added the `new_model_name` parameter to close #51 . Will add tests as well.

I also added an `only` field, that allows the reverse from exclude: only the mentioned fields will be included.

I am also thinking to add a class that does something similar. Basically, you would inherit from it set what model you want to use (similar to Django's Meta class for e.g. views) and which fields and in the constructor it calls the `sqlalchemy_to_pydantic` function (using the new class name as model name) and creates the schema.