### PR TITLE
Add support for Pydantic 2

### DIFF
--- a/pydantic_sqlalchemy/main.py
+++ b/pydantic_sqlalchemy/main.py
@@ -1,12 +1,20 @@
 from typing import Container, Optional, Type
 
-from pydantic import BaseConfig, BaseModel, create_model
+from pydantic import BaseModel, create_model
 from sqlalchemy.inspection import inspect
 from sqlalchemy.orm.properties import ColumnProperty
 
 
-class OrmConfig(BaseConfig):
-    orm_mode = True
+try:
+    from pydantic import ConfigDict
+
+    class OrmConfig(ConfigDict):
+        from_attributes = True
+except ImportError:
+    from pydantic import BaseConfig
+
+    class OrmConfig(BaseConfig):
+        orm_mode = True
 
 
 def sqlalchemy_to_pydantic(

--- a/pydantic_sqlalchemy/main.py
+++ b/pydantic_sqlalchemy/main.py
@@ -8,8 +8,7 @@ from sqlalchemy.orm.properties import ColumnProperty
 try:
     from pydantic import ConfigDict
 
-    class OrmConfig(ConfigDict):
-        from_attributes = True
+    OrmConfig = ConfigDict(from_attributes=True)
 except ImportError:
     from pydantic import BaseConfig
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pydantic-sqlalchemy"
-version = "0"
+version = "0.0.1"
 description = "Tools to convert SQLAlchemy models to Pydantic models"
 authors = ["Sebastián Ramírez <tiangolo@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.6"
 sqlalchemy = "^1.3.16"
-pydantic = "^1.5.1"
+pydantic = ">=1.5.1,<3.0.0"
 
 # Local development dependencies
 jupyter = {version = "^1.0.0", optional = true, extras = ["dev"]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.6"
-sqlalchemy = "^1.3.16"
+sqlalchemy = ">=1.3.16,<3.0.0"
 pydantic = ">=1.5.1,<3.0.0"
 
 # Local development dependencies


### PR DESCRIPTION
This adds support for Pydantic 2 in a backwards compatible way.

For anyone who wants to use this before it is merged, you can do:
```
pip3 install --upgrade git+https://github.com/MatthewScholefield/pydantic-sqlalchemy.git@master#egg=pydantic-sqlalchemy
```

I know there's [a PR](https://github.com/tiangolo/pydantic-sqlalchemy/pull/54) to add a notice to the README to deprecate the project, but I still feel the project is useful for cases where SQLModel isn't yet complete (ie. migrations which [the docs](https://sqlmodel.tiangolo.com/advanced/) are currently yet-to-be-written).