### PR TITLE
Fix Deprecation Issues and Update Code for Compatibility with Pydantic 2.0+ and SQLAlchemy 2.0+

### DIFF
--- a/pydantic_sqlalchemy/main.py
+++ b/pydantic_sqlalchemy/main.py
@@ -1,6 +1,6 @@
 from typing import Container, Optional, Type
 
-from pydantic import ConfigDict, BaseModel, create_model, Field
+from pydantic import ConfigDict, BaseModel, create_model
 from sqlalchemy.inspection import inspect
 from sqlalchemy.orm.properties import ColumnProperty
 

--- a/pydantic_sqlalchemy/main.py
+++ b/pydantic_sqlalchemy/main.py
@@ -1,12 +1,12 @@
 from typing import Container, Optional, Type
 
-from pydantic import BaseConfig, BaseModel, create_model
+from pydantic import ConfigDict, BaseModel, create_model, Field
 from sqlalchemy.inspection import inspect
 from sqlalchemy.orm.properties import ColumnProperty
 
 
-class OrmConfig(BaseConfig):
-    orm_mode = True
+class OrmConfig(ConfigDict):
+    from_attributes = True
 
 
 def sqlalchemy_to_pydantic(

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -3,7 +3,7 @@ pytest >=7.0.1,<9.0.0
 coverage[toml] >=6.2,<8.0
 mypy ==1.4.1
 ruff ==0.9.8
-typing-extensions ==4.6.1
+typing-extensions ==4.12.2
 
 pytest-cov ==4.1.0
 sqlalchemy-utc >=0.14.0,<0.15.0

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -7,3 +7,4 @@ typing-extensions ==4.12.2
 
 pytest-cov ==4.1.0
 sqlalchemy-utc >=0.14.0,<0.15.0
+pydantic >= 2.0.0

--- a/tests/test_pydantic_sqlalchemy.py
+++ b/tests/test_pydantic_sqlalchemy.py
@@ -104,11 +104,21 @@ def test_schema() -> None:
         "type": "object",
         "properties": {
             "id": {"title": "Id", "type": "integer"},
-            "name": {"title": "Name", "type": "string"},
-            "fullname": {"title": "Fullname", "type": "string"},
-            "nickname": {"title": "Nickname", "type": "string"},
-            "created": {"title": "Created", "type": "string", "format": "date-time"},
-            "updated": {"title": "Updated", "type": "string", "format": "date-time"},
+            "name": {"title": "Name", "type": "string", "default": None},
+            "fullname": {"title": "Fullname", "type": "string", "default": None},
+            "nickname": {"title": "Nickname", "type": "string", "default": None},
+            "created": {
+                "title": "Created",
+                "type": "string",
+                "format": "date-time",
+                "default": None,
+            },
+            "updated": {
+                "title": "Updated",
+                "type": "string",
+                "format": "date-time",
+                "default": None,
+            },
         },
         "required": ["id"],
     }
@@ -118,7 +128,7 @@ def test_schema() -> None:
         "properties": {
             "id": {"title": "Id", "type": "integer"},
             "email_address": {"title": "Email Address", "type": "string"},
-            "user_id": {"title": "User Id", "type": "integer"},
+            "user_id": {"title": "User Id", "type": "integer", "default": None},
         },
         "required": ["id", "email_address"],
     }

--- a/tests/test_pydantic_sqlalchemy.py
+++ b/tests/test_pydantic_sqlalchemy.py
@@ -3,8 +3,8 @@ from typing import List
 
 from pydantic_sqlalchemy import sqlalchemy_to_pydantic
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, create_engine
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import Session, relationship, sessionmaker
+
+from sqlalchemy.orm import Session, relationship, sessionmaker, declarative_base
 from sqlalchemy_utc import UtcDateTime
 
 Base = declarative_base()

--- a/tests/test_pydantic_sqlalchemy.py
+++ b/tests/test_pydantic_sqlalchemy.py
@@ -64,8 +64,8 @@ def test_defaults() -> None:
         addresses: List[PydanticAddress] = []
 
     user = db.query(User).first()
-    pydantic_user = PydanticUser.from_orm(user)
-    data = pydantic_user.dict()
+    pydantic_user = PydanticUser.model_validate(user)
+    data = pydantic_user.model_dump()
     assert isinstance(data["created"], datetime)
     assert isinstance(data["updated"], datetime)
     check_data = data.copy()
@@ -77,8 +77,8 @@ def test_defaults() -> None:
         "name": "ed",
         "nickname": "edsnickname",
     }
-    pydantic_user_with_addresses = PydanticUserWithAddresses.from_orm(user)
-    data = pydantic_user_with_addresses.dict()
+    pydantic_user_with_addresses = PydanticUserWithAddresses.model_validate(user)
+    data = pydantic_user_with_addresses.model_dump()
     assert isinstance(data["updated"], datetime)
     assert isinstance(data["created"], datetime)
     check_data = data.copy()
@@ -99,7 +99,7 @@ def test_defaults() -> None:
 def test_schema() -> None:
     PydanticUser = sqlalchemy_to_pydantic(User)
     PydanticAddress = sqlalchemy_to_pydantic(Address)
-    assert PydanticUser.schema() == {
+    assert PydanticUser.model_json_schema() == {
         "title": "User",
         "type": "object",
         "properties": {
@@ -112,7 +112,7 @@ def test_schema() -> None:
         },
         "required": ["id"],
     }
-    assert PydanticAddress.schema() == {
+    assert PydanticAddress.model_json_schema() == {
         "title": "Address",
         "type": "object",
         "properties": {
@@ -126,8 +126,8 @@ def test_schema() -> None:
 
 def test_config() -> None:
     class Config:
-        orm_mode = True
-        allow_population_by_field_name = True
+        from_attributes = True
+        populate_by_name = True
 
         @classmethod
         def alias_generator(cls, string: str) -> str:
@@ -142,8 +142,8 @@ def test_config() -> None:
         addresses: List[PydanticAddress] = []
 
     user = db.query(User).first()
-    pydantic_user_with_addresses = PydanticUserWithAddresses.from_orm(user)
-    data = pydantic_user_with_addresses.dict(by_alias=True)
+    pydantic_user_with_addresses = PydanticUserWithAddresses.model_validate(user)
+    data = pydantic_user_with_addresses.model_dump(by_alias=True)
     assert isinstance(data["created"], datetime)
     assert isinstance(data["updated"], datetime)
     check_data = data.copy()
@@ -169,8 +169,8 @@ def test_exclude() -> None:
         addresses: List[PydanticAddress] = []
 
     user = db.query(User).first()
-    pydantic_user_with_addresses = PydanticUserWithAddresses.from_orm(user)
-    data = pydantic_user_with_addresses.dict(by_alias=True)
+    pydantic_user_with_addresses = PydanticUserWithAddresses.model_validate(user)
+    data = pydantic_user_with_addresses.model_dump(by_alias=True)
     assert isinstance(data["created"], datetime)
     assert isinstance(data["updated"], datetime)
     check_data = data.copy()

--- a/tests/test_pydantic_sqlalchemy.py
+++ b/tests/test_pydantic_sqlalchemy.py
@@ -23,7 +23,7 @@ class User(Base):
     name = Column(String)
     fullname = Column(String)
     nickname = Column(String)
-    created = Column(DateTime, default=datetime.utcnow)
+    created = Column(DateTime, default=datetime.now(timezone.utc))
     updated = Column(UtcDateTime, default=utc_now, onupdate=utc_now)
 
     addresses = relationship(


### PR DESCRIPTION
Hello, I am Junbeom Lee

Thank you for your efforts in creating this valuable open-source library. 
I first discovered this library when ChatGPT recommended it for converting SQLAlchemy models to Pydantic models. I tried using it, but unfortunately, it requires Pydantic >2.0.0 and SQLAlchemy >2.0.0.

After checking, I noticed that Dependabot had attempted to update the dependencies but failed due to deprecation issues. To resolve this, I replaced the deprecated code.
I hope this pull request reaches you soon! Please let me know if there is anything I should change.

---

## Changes made 1: Replaced deprecated code with the new one

### **Pydantic:**

- **Classes:**
  - Replaced `BaseConfig` with `ConfigDict`
  
- **Methods:**
  - Replaced `PydanticUser.from_orm(user)` with `PydanticUser.model_validate(user)`
  - Replaced `pydantic_user.dict()` with `pydantic_user.model_dump()`
  - Replaced `PydanticUser.schema()` with `PydanticUser.model_json_schema()`

- **Attributes:**
  - Replaced `orm_mode = True` with `from_attributes = True`
  - Replaced `allow_population_by_field_name = True` with `populate_by_name = True`

### **SQLAlchemy:**
- Replaced `from sqlalchemy.ext.declarative import declarative_base` with `from sqlalchemy.orm import declarative_base`

## Changes made 2: Test schemas
- Updated test schemas to reflect `default: None` for nullable fields.
