### PR TITLE
👷 Upgrade actions/checkout from v5 to v6

### DIFF
--- a/.github/workflows/latest-changes.yml
+++ b/.github/workflows/latest-changes.yml
@@ -20,9 +20,7 @@ jobs:
   latest-changes:
     runs-on: ubuntu-latest
     steps:
-      # pin to actions/checkout@v5 for compatibility with latest-changes
-      # Ref: https://github.com/actions/checkout/issues/2313
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.PYDANTIC_SQLALCHEMY_LATEST_CHANGES }}
       - uses: tiangolo/latest-changes@0.4.1


### PR DESCRIPTION
https://github.com/actions/checkout/issues/2313 was fixed. :tada: