### PR TITLE
📝 Update docs badges: remove Publish badge, it doesn't give extra information

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,6 @@
 <a href="https://github.com/tiangolo/pydantic-sqlalchemy/actions?query=workflow%3ATest" target="_blank">
     <img src="https://github.com/tiangolo/pydantic-sqlalchemy/workflows/Test/badge.svg" alt="Test">
 </a>
-<a href="https://github.com/tiangolo/pydantic-sqlalchemy/actions?query=workflow%3APublish" target="_blank">
-    <img src="https://github.com/tiangolo/pydantic-sqlalchemy/workflows/Publish/badge.svg" alt="Publish">
-</a>
 <a href="https://codecov.io/gh/tiangolo/pydantic-sqlalchemy" target="_blank">
     <img src="https://img.shields.io/codecov/c/github/tiangolo/pydantic-sqlalchemy?color=%2334D058" alt="Coverage">
 </a>


### PR DESCRIPTION
## Summary
- Remove the Publish workflow badge from the docs badges.
- Keep the remaining status, coverage, and package badges unchanged.

## AI Disclaimer
Codex GPT 5.5, reviewed by hand.
