### PR TITLE
⬆️ Update issue-manager to 0.7.0

### DIFF
--- a/.github/workflows/issue-manager.yml
+++ b/.github/workflows/issue-manager.yml
@@ -12,14 +12,6 @@ jobs:
   issue-manager:
     runs-on: ubuntu-latest
     steps:
-    - uses: tiangolo/issue-manager@2fb3484ec9279485df8659e8ec73de262431737d # 0.6.0
+    - uses: tiangolo/issue-manager@8505bda3fd28623a64d93935cbe13fa23f14fd8b # 0.7.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        config: >
-            {
-              "answered": {
-                "users": ["tiangolo"],
-                "delay": 864000,
-                "message": "Assuming the original issue was solved, it will be automatically closed now. But feel free to add more comments or create new issues."
-              }
-            }


### PR DESCRIPTION
## Summary

- update the pinned `tiangolo/issue-manager` action to 0.7.0
- remove the inline issue-manager config so the workflow uses the new built-in defaults

## Validation

- Verified the transformed workflow references `tiangolo/issue-manager@8505bda3fd28623a64d93935cbe13fa23f14fd8b # 0.7.0`
- Verified the inline `config` block is removed

## AI Disclaimer

Using Codex with GPT-5.5. Reviewed manually.
