### PR TITLE
👷 Update issue-manager to 0.7.1

### DIFF
--- a/.github/workflows/issue-manager.yml
+++ b/.github/workflows/issue-manager.yml
@@ -12,6 +12,6 @@ jobs:
   issue-manager:
     runs-on: ubuntu-latest
     steps:
-    - uses: tiangolo/issue-manager@8505bda3fd28623a64d93935cbe13fa23f14fd8b # 0.7.0
+    - uses: tiangolo/issue-manager@75d60679db1ea348f6f6ea1d0e20de80a7c04645 # 0.7.1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Changes

Updates the Issue Manager workflow to pin `tiangolo/issue-manager` to the released `0.7.1` commit.

## Validation

- Updated only the workflow `uses:` reference for `tiangolo/issue-manager`.
- Verified the updated workflow content includes `tiangolo/issue-manager@75d60679db1ea348f6f6ea1d0e20de80a7c04645 # 0.7.1`.

## AI Disclaimer

Using Codex with GPT-5. Reviewed manually.
