### PR TITLE
⬆️ Update latest-changes to 0.6.1

### DIFF
--- a/.github/workflows/latest-changes.yml
+++ b/.github/workflows/latest-changes.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           token: ${{ secrets.PYDANTIC_SQLALCHEMY_LATEST_CHANGES }} # zizmor: ignore[secrets-outside-env]
           persist-credentials: true # required by tiangolo/latest-changes
-      - uses: tiangolo/latest-changes@eb3f6e7ff0073896ecb561e774a121de9418fa06 # 0.5.0
+      - uses: tiangolo/latest-changes@c9b73efbc8992ef1a401e4235ea307a8ca8a724b # 0.6.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           latest_changes_file: release-notes.md


### PR DESCRIPTION
## Description

Update the `tiangolo/latest-changes` GitHub Action pin to `0.6.1`.

This picks up the action runtime fix so the Docker action uses its baked-in virtual environment instead of letting `uv run` inspect the consumer repository Python version configuration.

## Checks

- `yq '.jobs' .github/workflows/latest-changes.yml`
- `git diff --check`

## AI Disclaimer

Using Codex with GPT-5. Reviewed manually.
